### PR TITLE
Fix errors that occur when Cassandra has NULL data

### DIFF
--- a/bulk-load/src/main/java/com/doitintl/etl/pojos/BaseRow.java
+++ b/bulk-load/src/main/java/com/doitintl/etl/pojos/BaseRow.java
@@ -33,10 +33,13 @@ public abstract class BaseRow implements Serializable {
 	 * @param value Cell's value
 	 * @return A BigTable row mutation
 	 */
-	Mutation getMutation(String family, String columnQualifier, String value){
+	Mutation getMutation(String family, String columnQualifier, Object value){
+		if(value == null | value.toString() == null){
+			value = "null";
+		}
 		return Mutation
 				.newBuilder()
-				.setSetCell(getCell(family,columnQualifier, value))
+				.setSetCell(getCell(family,columnQualifier, value.toString()))
 				.build();
 	}
 


### PR DESCRIPTION
While trying to use and develop with this Demo, I ran into an issue with Dataflow where it errored out with NullPointerExceptions. 

Turns out some data from Cassandra was NULL. This change *should* solve this problem. This is because you would now be accepting an Object in the mutation and converting it to a string. If the string is Null you can set it to NULL which seems to properly work on BT. 

Please check and confirm or loop back in with me for questions. There might be more unintended consequences of this that I'm not aware of.